### PR TITLE
Removed redundant mapping variables

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -1,20 +1,32 @@
 local AF = AdvancedFilters
 local util = AF.util
 
+local filterTypeToGroupName = {}
+filterTypeToGroupName = AF.filterTypes2Names
+
 local function GetFilterCallbackForWeaponType(filterTypes)
-    return function(slot)
+    return function(slot, slotIndex)
+        if slotIndex ~= nil and type(slot) ~= "table" then
+            slot = util.prepareSlot(slot, slotIndex)
+        end
         local itemLink = util.GetItemLink(slot)
+        if itemLink == nil then return false end
 
         local weaponType = GetItemLinkWeaponType(itemLink)
 
         for i=1, #filterTypes do
-            if(filterTypes[i] == weaponType) then return true end
+            if(filterTypes[i] == weaponType) then
+                return true
+            end
         end
     end
 end
 
 local function GetFilterCallbackForArmorType(filterTypes)
-    return function(slot)
+    return function(slot, slotIndex)
+        if slotIndex ~= nil and type(slot) ~= "table" then
+            slot = util.prepareSlot(slot, slotIndex)
+        end
         local itemLink = util.GetItemLink(slot)
 
         local armorType = GetItemLinkArmorType(itemLink)
@@ -25,20 +37,59 @@ local function GetFilterCallbackForArmorType(filterTypes)
     end
 end
 
-local function GetFilterCallbackForGear(filterTypes)
-    return function(slot)
+local function GetFilterCallbackForGear(filterTypes, armorTypes)
+    return function(slot, slotIndex)
+        if slotIndex ~= nil and type(slot) ~= "table" then
+            slot = util.prepareSlot(slot, slotIndex)
+        end
+        local itemLink = util.GetItemLink(slot)
+
+        local goOn = false
+        if armorTypes ~= nil then
+            local armorType = GetItemLinkArmorType(itemLink)
+            for i=1, #armorTypes do
+                if armorTypes[i] == armorType then
+                    goOn = true
+                    break
+                end
+            end
+        else
+            goOn = true
+        end
+        if goOn then
+            local _, _, _, equipType = GetItemLinkInfo(itemLink)
+
+            for i=1, #filterTypes do
+                if filterTypes[i] == equipType then return true end
+            end
+        end
+        return false
+    end
+end
+
+local function GetFilterCallbackForJewelry(filterTypes, itemTraitType)
+    return function(slot, slotIndex)
+        if slotIndex ~= nil and type(slot) ~= "table" then
+            slot = util.prepareSlot(slot, slotIndex)
+        end
         local itemLink = util.GetItemLink(slot)
 
         local _, _, _, equipType = GetItemLinkInfo(itemLink)
 
         for i=1, #filterTypes do
-            if filterTypes[i] == equipType then return true end
+            if filterTypes[i] == equipType then
+                local checkItemTraitType = GetItemLinkTraitInfo(itemLink)
+                if itemTraitType == checkItemTraitType then return true end
+            end
         end
     end
 end
 
 local function GetFilterCallbackForClothing()
-    return function(slot)
+    return function(slot, slotIndex)
+        if slotIndex ~= nil and type(slot) ~= "table" then
+            slot = util.prepareSlot(slot, slotIndex)
+        end
         local itemLink = util.GetItemLink(slot)
 
         local armorType = GetItemLinkArmorType(itemLink)
@@ -55,7 +106,10 @@ local function GetFilterCallbackForClothing()
 end
 
 local function GetFilterCallbackForTrophy()
-    return function(slot)
+    return function(slot, slotIndex)
+        if slotIndex ~= nil and type(slot) ~= "table" then
+            slot = util.prepareSlot(slot, slotIndex)
+        end
         local itemLink = util.GetItemLink(slot)
 
         local itemType = GetItemLinkItemType(itemLink)
@@ -69,7 +123,10 @@ local function GetFilterCallbackForTrophy()
 end
 
 local function GetFilterCallbackForFence()
-    return function(slot)
+    return function(slot, slotIndex)
+        if slotIndex ~= nil and type(slot) ~= "table" then
+            slot = util.prepareSlot(slot, slotIndex)
+        end
         local itemLink = util.GetItemLink(slot)
 
         local itemType = GetItemLinkItemType(itemLink)
@@ -85,7 +142,10 @@ local function GetFilterCallbackForFence()
 end
 
 local function GetFilterCallbackForProvisioningIngredient(ingredientType)
-    return function(slot)
+    return function(slot, slotIndex)
+        if slotIndex ~= nil and type(slot) ~= "table" then
+            slot = util.prepareSlot(slot, slotIndex)
+        end
         local lookup = {
             --meats (health)
             ["28609"] = "Food", --Game
@@ -220,7 +280,10 @@ local function GetFilterCallbackForProvisioningIngredient(ingredientType)
 end
 
 local function GetFilterCallbackForStyleMaterial(categoryConst)
-    return function(slot)
+    return function(slot, slotIndex)
+        if slotIndex ~= nil and type(slot) ~= "table" then
+            slot = util.prepareSlot(slot, slotIndex)
+        end
         local itemLink = util.GetItemLink(slot)
 
         if categoryConst == AF.util.LibMotifCategories:GetMotifCategory(itemLink) then
@@ -232,7 +295,10 @@ end
 local function GetFilterCallbackForSpecializedItemtype(sItemTypes)
     if(not sItemTypes) then return function(slot) return true end end
 
-    return function(slot)
+    return function(slot, slotIndex)
+        if slotIndex ~= nil and type(slot) ~= "table" then
+            slot = util.prepareSlot(slot, slotIndex)
+        end
         local itemLink = util.GetItemLink(slot)
 
         local _, sItemType = GetItemLinkItemType(itemLink)
@@ -246,11 +312,12 @@ end
 local function GetFilterCallback(filterTypes)
     if(not filterTypes) then return function(slot) return true end end
 
-    return function(slot)
+    return function(slot, slotIndex)
+        if slotIndex ~= nil and type(slot) ~= "table" then
+            slot = util.prepareSlot(slot, slotIndex)
+        end
         local itemLink = util.GetItemLink(slot)
-
         local itemType = GetItemLinkItemType(itemLink)
-
         for i=1, #filterTypes do
             if filterTypes[i] == itemType then return true end
         end
@@ -261,7 +328,7 @@ AF.subfilterCallbacks = {
     All = {
         addonDropdownCallbacks = {},
         dropdownCallbacks = {
-            {name = "All", filterCallback = GetFilterCallback(nil)},
+            {name = AF_CONST_ALL, filterCallback = GetFilterCallback(nil)},
         },
         All = {
             filterCallback = GetFilterCallback(nil),
@@ -286,9 +353,9 @@ AF.subfilterCallbacks = {
         TwoHand = {
             filterCallback = GetFilterCallbackForWeaponType({WEAPONTYPE_TWO_HANDED_AXE, WEAPONTYPE_TWO_HANDED_HAMMER, WEAPONTYPE_TWO_HANDED_SWORD}),
             dropdownCallbacks = {
-                {name = "2HAxe", filterCallback = GetFilterCallbackForWeaponType({WEAPONTYPE_TWO_HANDED_AXE})},
-                {name = "2HHammer", filterCallback = GetFilterCallbackForWeaponType({WEAPONTYPE_TWO_HANDED_HAMMER})},
-                {name = "2HSword", filterCallback = GetFilterCallbackForWeaponType({WEAPONTYPE_TWO_HANDED_SWORD})},
+                {name = "TwoHandAxe", filterCallback = GetFilterCallbackForWeaponType({WEAPONTYPE_TWO_HANDED_AXE})},
+                {name = "TwoHandHammer", filterCallback = GetFilterCallbackForWeaponType({WEAPONTYPE_TWO_HANDED_HAMMER})},
+                {name = "TwoHandSword", filterCallback = GetFilterCallbackForWeaponType({WEAPONTYPE_TWO_HANDED_SWORD})},
             },
         },
         Bow = {
@@ -306,6 +373,57 @@ AF.subfilterCallbacks = {
         HealStaff = {
             filterCallback = GetFilterCallbackForWeaponType({WEAPONTYPE_HEALING_STAFF}),
             dropdownCallbacks = {},
+        },
+    },
+    WeaponsSmithing = {
+        addonDropdownCallbacks = {},
+        All = {
+            filterCallback = GetFilterCallback(nil),
+            dropdownCallbacks = {},
+        },
+        OneHand = {
+            filterCallback = GetFilterCallbackForWeaponType({WEAPONTYPE_AXE, WEAPONTYPE_HAMMER, WEAPONTYPE_SWORD, WEAPONTYPE_DAGGER}),
+            dropdownCallbacks = {
+                {name = "Axe", filterCallback = GetFilterCallbackForWeaponType({WEAPONTYPE_AXE})},
+                {name = "Hammer", filterCallback = GetFilterCallbackForWeaponType({WEAPONTYPE_HAMMER})},
+                {name = "Sword", filterCallback = GetFilterCallbackForWeaponType({WEAPONTYPE_SWORD})},
+                {name = "Dagger", filterCallback = GetFilterCallbackForWeaponType({WEAPONTYPE_DAGGER})},
+            },
+        },
+        TwoHand = {
+            filterCallback = GetFilterCallbackForWeaponType({WEAPONTYPE_TWO_HANDED_AXE, WEAPONTYPE_TWO_HANDED_HAMMER, WEAPONTYPE_TWO_HANDED_SWORD}),
+            dropdownCallbacks = {
+                {name = "TwoHandAxe", filterCallback = GetFilterCallbackForWeaponType({WEAPONTYPE_TWO_HANDED_AXE})},
+                {name = "TwoHandHammer", filterCallback = GetFilterCallbackForWeaponType({WEAPONTYPE_TWO_HANDED_HAMMER})},
+                {name = "TwoHandSword", filterCallback = GetFilterCallbackForWeaponType({WEAPONTYPE_TWO_HANDED_SWORD})},
+            },
+        },
+    },
+    WeaponsWoodworking = {
+        addonDropdownCallbacks = {},
+        All = {
+            filterCallback = GetFilterCallback(nil),
+            dropdownCallbacks = {},
+        },
+        Bow = {
+            filterCallback = GetFilterCallbackForWeaponType({WEAPONTYPE_BOW}),
+            dropdownCallbacks = {
+                {name = "Bow", filterCallback = GetFilterCallbackForWeaponType({WEAPONTYPE_BOW})},
+            },
+        },
+        DestructionStaff = {
+            filterCallback = GetFilterCallbackForWeaponType({WEAPONTYPE_FIRE_STAFF, WEAPONTYPE_FROST_STAFF, WEAPONTYPE_LIGHTNING_STAFF}),
+            dropdownCallbacks = {
+                {name = "Fire", filterCallback = GetFilterCallbackForWeaponType({WEAPONTYPE_FIRE_STAFF})},
+                {name = "Frost", filterCallback = GetFilterCallbackForWeaponType({WEAPONTYPE_FROST_STAFF})},
+                {name = "Lightning", filterCallback = GetFilterCallbackForWeaponType({WEAPONTYPE_LIGHTNING_STAFF})},
+            },
+        },
+        HealStaff = {
+            filterCallback = GetFilterCallbackForWeaponType({WEAPONTYPE_HEALING_STAFF}),
+            dropdownCallbacks = {
+                {name = "HealStaff", filterCallback = GetFilterCallbackForWeaponType({WEAPONTYPE_HEALING_STAFF})},
+            },
         },
     },
     Armor = {
@@ -341,16 +459,111 @@ AF.subfilterCallbacks = {
             filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_OFF_HAND}),
             dropdownCallbacks = {},
         },
-        Jewelry = {
-            filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_RING, EQUIP_TYPE_NECK}),
-            dropdownCallbacks = {
-                {name = "Ring", filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_RING})},
-                {name = "Neck", filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_NECK})},
-            },
-        },
         Vanity = {
             filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_DISGUISE, EQUIP_TYPE_COSTUME}),
             dropdownCallbacks = {},
+        },
+    },
+    ArmorSmithing = {
+        addonDropdownCallbacks = {},
+        All = {
+            filterCallback = GetFilterCallback(nil),
+            dropdownCallbacks = {},
+        },
+        Heavy = {
+            filterCallback = GetFilterCallbackForArmorType({ARMORTYPE_HEAVY}),
+            dropdownCallbacks = {
+                {name = "Head", filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_HEAD})},
+                {name = "Chest", filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_CHEST})},
+                {name = "Shoulders", filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_SHOULDERS})},
+                {name = "Hand", filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_HAND})},
+                {name = "Waist", filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_WAIST})},
+                {name = "Legs", filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_LEGS})},
+                {name = "Feet", filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_FEET})},
+            },
+        },
+    },
+    ArmorClothier = {
+        addonDropdownCallbacks = {},
+        All = {
+            filterCallback = GetFilterCallback(nil),
+            dropdownCallbacks = {},
+        },
+        LightArmor = {
+            filterCallback = GetFilterCallbackForArmorType({ARMORTYPE_LIGHT}),
+            dropdownCallbacks = {
+                {name = "LightHead", filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_HEAD}, {ARMORTYPE_LIGHT})},
+                {name = "LightChest", filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_CHEST}, {ARMORTYPE_LIGHT})},
+                {name = "LightShoulders", filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_SHOULDERS}, {ARMORTYPE_LIGHT})},
+                {name = "LightHand", filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_HAND}, {ARMORTYPE_LIGHT})},
+                {name = "LightWaist", filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_WAIST}, {ARMORTYPE_LIGHT})},
+                {name = "LightLegs", filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_LEGS}, {ARMORTYPE_LIGHT})},
+                {name = "LightFeet", filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_FEET}, {ARMORTYPE_LIGHT})},
+            },
+        },
+        Medium = {
+            filterCallback = GetFilterCallbackForArmorType({ARMORTYPE_MEDIUM}),
+            dropdownCallbacks = {
+                {name = "MediumHead", filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_HEAD}, {ARMORTYPE_MEDIUM})},
+                {name = "MediumChest", filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_CHEST}, {ARMORTYPE_MEDIUM})},
+                {name = "MediumShoulders", filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_SHOULDERS}, {ARMORTYPE_MEDIUM})},
+                {name = "MediumHand", filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_HAND}, {ARMORTYPE_MEDIUM})},
+                {name = "MediumWaist", filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_WAIST}, {ARMORTYPE_MEDIUM})},
+                {name = "MediumLegs", filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_LEGS}, {ARMORTYPE_MEDIUM})},
+                {name = "MediumFeet", filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_FEET}, {ARMORTYPE_MEDIUM})},
+            },
+        },
+    },
+    ArmorWoodworking = {
+        addonDropdownCallbacks = {},
+        All = {
+            filterCallback = GetFilterCallback(nil),
+            dropdownCallbacks = {},
+        },
+        Shield = {
+            filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_OFF_HAND}),
+            dropdownCallbacks = {
+                {name = "Shield", filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_OFF_HAND})},
+            },
+        },
+    },
+    Jewelry = {
+        addonDropdownCallbacks = {},
+        All = {
+            filterCallback = GetFilterCallback(nil),
+            dropdownCallbacks = {},
+        },
+        Neck = {
+            filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_NECK}),
+            dropdownCallbacks = {
+                {name = "Arcane", filterCallback = GetFilterCallbackForJewelry({EQUIP_TYPE_NECK}, ITEM_TRAIT_TYPE_JEWELRY_ARCANE)},
+                {name = "Bloodthirsty", filterCallback = GetFilterCallbackForJewelry({EQUIP_TYPE_NECK}, ITEM_TRAIT_TYPE_JEWELRY_BLOODTHIRSTY)},
+                {name = "Harmony", filterCallback = GetFilterCallbackForJewelry({EQUIP_TYPE_NECK}, ITEM_TRAIT_TYPE_JEWELRY_HARMONY)},
+                {name = "Healthy", filterCallback = GetFilterCallbackForJewelry({EQUIP_TYPE_NECK}, ITEM_TRAIT_TYPE_JEWELRY_HEALTHY)},
+                {name = "Infused", filterCallback = GetFilterCallbackForJewelry({EQUIP_TYPE_NECK}, ITEM_TRAIT_TYPE_JEWELRY_INFUSED)},
+                {name = "Intricate", filterCallback = GetFilterCallbackForJewelry({EQUIP_TYPE_NECK}, ITEM_TRAIT_TYPE_JEWELRY_INTRICATE)},
+                {name = "Ornate", filterCallback = GetFilterCallbackForJewelry({EQUIP_TYPE_NECK}, ITEM_TRAIT_TYPE_JEWELRY_ORNATE)},
+                {name = "Protective", filterCallback = GetFilterCallbackForJewelry({EQUIP_TYPE_NECK}, ITEM_TRAIT_TYPE_JEWELRY_PROTECTIVE)},
+                {name = "Robust", filterCallback = GetFilterCallbackForJewelry({EQUIP_TYPE_NECK}, ITEM_TRAIT_TYPE_JEWELRY_ROBUST)},
+                {name = "Swift", filterCallback = GetFilterCallbackForJewelry({EQUIP_TYPE_NECK}, ITEM_TRAIT_TYPE_JEWELRY_SWIFT)},
+                {name = "Triune", filterCallback = GetFilterCallbackForJewelry({EQUIP_TYPE_NECK}, ITEM_TRAIT_TYPE_JEWELRY_TRIUNE)},
+            },
+        },
+        Ring = {
+            filterCallback = GetFilterCallbackForGear({EQUIP_TYPE_RING}),
+            dropdownCallbacks = {
+                {name = "Arcane", filterCallback = GetFilterCallbackForJewelry({EQUIP_TYPE_RING}, ITEM_TRAIT_TYPE_JEWELRY_ARCANE)},
+                {name = "Bloodthirsty", filterCallback = GetFilterCallbackForJewelry({EQUIP_TYPE_RING}, ITEM_TRAIT_TYPE_JEWELRY_BLOODTHIRSTY)},
+                {name = "Harmony", filterCallback = GetFilterCallbackForJewelry({EQUIP_TYPE_RING}, ITEM_TRAIT_TYPE_JEWELRY_HARMONY)},
+                {name = "Healthy", filterCallback = GetFilterCallbackForJewelry({EQUIP_TYPE_RING}, ITEM_TRAIT_TYPE_JEWELRY_HEALTHY)},
+                {name = "Infused", filterCallback = GetFilterCallbackForJewelry({EQUIP_TYPE_RING}, ITEM_TRAIT_TYPE_JEWELRY_INFUSED)},
+                {name = "Intricate", filterCallback = GetFilterCallbackForJewelry({EQUIP_TYPE_RING}, ITEM_TRAIT_TYPE_JEWELRY_INTRICATE)},
+                {name = "Ornate", filterCallback = GetFilterCallbackForJewelry({EQUIP_TYPE_RING}, ITEM_TRAIT_TYPE_JEWELRY_ORNATE)},
+                {name = "Protective", filterCallback = GetFilterCallbackForJewelry({EQUIP_TYPE_RING}, ITEM_TRAIT_TYPE_JEWELRY_PROTECTIVE)},
+                {name = "Robust", filterCallback = GetFilterCallbackForJewelry({EQUIP_TYPE_RING}, ITEM_TRAIT_TYPE_JEWELRY_ROBUST)},
+                {name = "Swift", filterCallback = GetFilterCallbackForJewelry({EQUIP_TYPE_RING}, ITEM_TRAIT_TYPE_JEWELRY_SWIFT)},
+                {name = "Triune", filterCallback = GetFilterCallbackForJewelry({EQUIP_TYPE_RING}, ITEM_TRAIT_TYPE_JEWELRY_TRIUNE)},
+            },
         },
     },
     Consumables = {
@@ -447,6 +660,20 @@ AF.subfilterCallbacks = {
                 {name = "RareIngredient", filterCallback = GetFilterCallbackForSpecializedItemtype({SPECIALIZED_ITEMTYPE_INGREDIENT_RARE})},
             },
         },
+        JewelryCrafting = {
+            filterCallback = GetFilterCallback({
+                ITEMTYPE_JEWELRYCRAFTING_BOOSTER,
+                ITEMTYPE_JEWELRYCRAFTING_MATERIAL,
+                ITEMTYPE_JEWELRYCRAFTING_RAW_BOOSTER,
+                ITEMTYPE_JEWELRYCRAFTING_RAW_MATERIAL,
+            }),
+            dropdownCallbacks = {
+                {name = "Plating", filterCallback = GetFilterCallback({ITEMTYPE_JEWELRYCRAFTING_BOOSTER})},
+                {name = "RefinedMaterial", filterCallback = GetFilterCallback({ITEMTYPE_JEWELRYCRAFTING_MATERIAL})},
+                {name = "RawPlating", filterCallback = GetFilterCallback({ITEMTYPE_JEWELRYCRAFTING_RAW_BOOSTER})},
+                {name = "RawMaterial", filterCallback = GetFilterCallback({ITEMTYPE_JEWELRYCRAFTING_RAW_MATERIAL})},
+            },
+        },
         Style = {
             filterCallback = GetFilterCallback({ITEMTYPE_STYLE_MATERIAL, ITEMTYPE_RAW_MATERIAL}),
             dropdownCallbacks = {
@@ -458,6 +685,7 @@ AF.subfilterCallbacks = {
                 {name = "CrownStyle", filterCallback = GetFilterCallbackForStyleMaterial(LMC_MOTIF_CATEGORY_CROWN)},
             },
         },
+        --[[
         WeaponTrait = {
             filterCallback = GetFilterCallback({ITEMTYPE_WEAPON_TRAIT}),
             dropdownCallbacks = {},
@@ -465,6 +693,24 @@ AF.subfilterCallbacks = {
         ArmorTrait = {
             filterCallback = GetFilterCallback({ITEMTYPE_ARMOR_TRAIT}),
             dropdownCallbacks = {},
+        },
+        JewelryTrait = {
+            filterCallback = GetFilterCallback({ITEMTYPE_JEWELRY_TRAIT, ITEMTYPE_JEWELRY_RAW_TRAIT}),
+            dropdownCallbacks = {
+                {name = "RawMaterial", filterCallback = GetFilterCallback({ITEMTYPE_JEWELRY_RAW_TRAIT})},
+                {name = "RefinedMaterial", filterCallback = GetFilterCallback({ITEMTYPE_JEWELRY_TRAIT})},
+            },
+        },
+        ]]
+        AllTraits = {
+            filterCallback = GetFilterCallback({ITEMTYPE_WEAPON_TRAIT, ITEMTYPE_ARMOR_TRAIT, ITEMTYPE_JEWELRY_TRAIT, ITEMTYPE_JEWELRY_RAW_TRAIT}),
+            dropdownCallbacks = {
+                {name = "WeaponTrait", filterCallback = GetFilterCallback({ITEMTYPE_WEAPON_TRAIT})},
+                {name = "ArmorTrait", filterCallback = GetFilterCallback({ITEMTYPE_ARMOR_TRAIT})},
+                {name = "JewelryTrait", filterCallback = GetFilterCallback({ITEMTYPE_JEWELRY_TRAIT, ITEMTYPE_JEWELRY_RAW_TRAIT})},
+                {name = "RawMaterial", filterCallback = GetFilterCallback({ITEMTYPE_JEWELRY_RAW_TRAIT})},
+                {name = "RefinedMaterial", filterCallback = GetFilterCallback({ITEMTYPE_JEWELRY_TRAIT})},
+            },
         },
         FurnishingMat = {
             filterCallback = GetFilterCallback({ITEMTYPE_FURNISHING_MATERIAL}),
@@ -727,6 +973,32 @@ AF.subfilterCallbacks = {
             dropdownCallbacks = {},
         },
     },
+    Runes = {
+        addonDropdownCallbacks = {},
+        All = {
+            filterCallback = GetFilterCallback(nil),
+            dropdownCallbacks = {},
+        },
+    },
+    Glyphs = {
+        addonDropdownCallbacks = {},
+        All = {
+            filterCallback = GetFilterCallback(nil),
+            dropdownCallbacks = {},
+        },
+        WeaponGlyph = {
+            filterCallback = GetFilterCallback({ITEMTYPE_GLYPH_WEAPON}),
+            dropdownCallbacks = {},
+        },
+        ArmorGlyph = {
+            filterCallback = GetFilterCallback({ITEMTYPE_GLYPH_ARMOR}),
+            dropdownCallbacks = {},
+        },
+        JewelryGlyph = {
+            filterCallback = GetFilterCallback({ITEMTYPE_GLYPH_JEWELRY}),
+            dropdownCallbacks = {},
+        },
+    },
     Provisioning = {
         addonDropdownCallbacks = {},
         All = {
@@ -799,29 +1071,152 @@ AF.subfilterCallbacks = {
             filterCallback = GetFilterCallback({ITEMTYPE_ARMOR_TRAIT}),
             dropdownCallbacks = {},
         },
+        JewelryTrait = {
+            filterCallback = GetFilterCallback({ITEMTYPE_JEWELRY_TRAIT, ITEMTYPE_JEWELRY_RAW_TRAIT}),
+            dropdownCallbacks = {
+                {name = "RawMaterial", filterCallback = GetFilterCallback({ITEMTYPE_JEWELRY_RAW_TRAIT})},
+                {name = "RefinedMaterial", filterCallback = GetFilterCallback({ITEMTYPE_JEWELRY_TRAIT})},
+            },
+        },
+    },
+    JewelryCrafting = {
+        addonDropdownCallbacks = {},
+        All = {
+            filterCallback = GetFilterCallback(nil),
+            dropdownCallbacks = {},
+        },
+        Plating = {
+            filterCallback = GetFilterCallback({ITEMTYPE_JEWELRYCRAFTING_BOOSTER}),
+            dropdownCallbacks = {},
+        },
+        RefinedMaterial = {
+            filterCallback = GetFilterCallback({ITEMTYPE_JEWELRYCRAFTING_MATERIAL}),
+            dropdownCallbacks = {},
+        },
+        RawPlating = {
+            filterCallback = GetFilterCallback({ITEMTYPE_JEWELRYCRAFTING_RAW_BOOSTER}),
+            dropdownCallbacks = {},
+        },
+        RawMaterial = {
+            filterCallback = GetFilterCallback({ITEMTYPE_JEWELRYCRAFTING_RAW_MATERIAL}),
+            dropdownCallbacks = {},
+        },
+        FurnishingMat = {
+            filterCallback = GetFilterCallback({ITEMTYPE_FURNISHING_MATERIAL}),
+            dropdownCallbacks = {},
+        },
+    },
+    JewelryCraftingStationRefine = {
+        addonDropdownCallbacks = {},
+        All = {
+            filterCallback = GetFilterCallback(nil),
+            dropdownCallbacks = {},
+        },
+        RawPlating = {
+            filterCallback = GetFilterCallback({ITEMTYPE_JEWELRYCRAFTING_RAW_BOOSTER}),
+            dropdownCallbacks = {},
+        },
+        RawMaterial = {
+            filterCallback = GetFilterCallback({ITEMTYPE_JEWELRYCRAFTING_RAW_MATERIAL}),
+            dropdownCallbacks = {},
+        },
+        RawTrait = {
+            filterCallback = GetFilterCallback({ITEMTYPE_JEWELRY_RAW_TRAIT}),
+            dropdownCallbacks = {},
+        },
+    },
+    RefineSmithing = {
+        addonDropdownCallbacks = {},
+        All = {
+            filterCallback = GetFilterCallback(nil),
+            dropdownCallbacks = {},
+        },
+        RawMaterial = {
+            filterCallback = GetFilterCallback({ITEMTYPE_BLACKSMITHING_RAW_MATERIAL, ITEMTYPE_RAW_MATERIAL}),
+            dropdownCallbacks = {},
+        },
+    },
+    RefineClothier = {
+        addonDropdownCallbacks = {},
+        All = {
+            filterCallback = GetFilterCallback(nil),
+            dropdownCallbacks = {},
+        },
+        RawMaterial = {
+            filterCallback = GetFilterCallback({ITEMTYPE_CLOTHIER_RAW_MATERIAL, ITEMTYPE_RAW_MATERIAL}),
+            dropdownCallbacks = {},
+        },
+    },
+    RefineWoodworking = {
+        addonDropdownCallbacks = {},
+        All = {
+            filterCallback = GetFilterCallback(nil),
+            dropdownCallbacks = {},
+        },
+        RawMaterial = {
+            filterCallback = GetFilterCallback({ITEMTYPE_WOODWORKING_RAW_MATERIAL, ITEMTYPE_RAW_MATERIAL}),
+            dropdownCallbacks = {},
+        },
     },
 }
+--Clones of subfilterCallbacks
+AF.subfilterCallbacks.JewelryCraftingStation = AF.subfilterCallbacks.Jewelry
+
+local function BuildAddonInformation(filterInformation)
+    if filterInformation == nil then return nil end
+    local addonInformation = {
+        submenuName         = filterInformation.submenuName,
+        callbackTable       = filterInformation.callbackTable,
+        subfilters          = filterInformation.subfilters,
+        excludeSubfilters   = filterInformation.excludeSubfilters,
+        generator           = filterInformation.generator,
+        excludeFilterPanels = filterInformation.excludeFilterPanels,
+        onlyGroups          = filterInformation.onlyGroups,
+    }
+    return addonInformation
+end
+
+function AdvancedFilters_RemoveDuplicateAddonPlugin(filterInformation, groupName)
+    if filterInformation == nil then return false end
+    groupName = groupName or filterTypeToGroupName[filterInformation.filterType]
+    local addonInformation = BuildAddonInformation(filterInformation)
+    if addonInformation == nil then return false end
+
+    --Check if the same addon information is already in the callback tables for the filterType
+    --and remove the old one, before adding the same/newer one again
+    local removedDuplicate = false
+    if AF.subfilterCallbacks[groupName].addonDropdownCallbacks ~= nil then
+        local existingAFSubfilterCallbacksInfo = AF.subfilterCallbacks[groupName].addonDropdownCallbacks
+        for index, subfilterCallbacksInfo in pairs(existingAFSubfilterCallbacksInfo) do
+            --FilterInformation got a submenu? Compare the submenu names and remove exisitng before re-adding this
+            if addonInformation.submenuName ~= nil then
+                if subfilterCallbacksInfo.submenuName ~= nil and subfilterCallbacksInfo.submenuName == addonInformation.submenuName then
+                    --Remove this entry from the subfiltercallbacks as the same submenu will be added again
+                    table.remove(existingAFSubfilterCallbacksInfo, index)
+                    removedDuplicate = true
+                end
+            else
+                --No submenu name is given: Compare the callbackTable contents
+                local newPluginCallbackTable = addonInformation.callbackTable
+                local existingSubfilterCallbacksTableAtGroup = subfilterCallbacksInfo.callbackTable
+                if newPluginCallbackTable.name ~= nil and existingSubfilterCallbacksTableAtGroup ~= nil then
+                    --Check each entry of the exisitng addon dropdown plugin callbackTable
+                    for cbTabIndex, cbTabEntry in pairs(existingSubfilterCallbacksTableAtGroup) do
+                        if cbTabEntry ~= nil and cbTabEntry.name ~= nil and cbTabEntry.name == newPluginCallbackTable.name then
+                            --Same name of the callback plugin table was found: Remove the old plugin callbackTable completely
+                            --Remove this entry from the subfiltercallbacks as the same submenu will be added again
+                            table.remove(existingAFSubfilterCallbacksInfo, index)
+                            removedDuplicate = true
+                        end
+                    end
+                end
+            end
+        end
+    end
+    return removedDuplicate
+end
 
 function AdvancedFilters_RegisterFilter(filterInformation)
-    local filterTypeToGroupName = {
-        [ITEMFILTERTYPE_ALL] = "All",
-        [ITEMFILTERTYPE_WEAPONS] = "Weapons",
-        [ITEMFILTERTYPE_ARMOR] = "Armor",
-        [ITEMFILTERTYPE_CONSUMABLE] = "Consumables",
-        [ITEMFILTERTYPE_CRAFTING] = "Crafting",
-        [ITEMFILTERTYPE_FURNISHING] = "Furnishings",
-        [ITEMFILTERTYPE_MISCELLANEOUS] = "Miscellaneous",
-        --[ITEMFILTERTYPE_JUNK] = "Junk",
-        [ITEMFILTERTYPE_BLACKSMITHING] = "Blacksmithing",
-        [ITEMFILTERTYPE_CLOTHING] = "Clothing",
-        [ITEMFILTERTYPE_WOODWORKING] = "Woodworking",
-        [ITEMFILTERTYPE_ALCHEMY] = "Alchemy",
-        [ITEMFILTERTYPE_ENCHANTING] = "Enchanting",
-        [ITEMFILTERTYPE_PROVISIONING] = "Provisioning",
-        [ITEMFILTERTYPE_STYLE_MATERIALS] = "Style",
-        [ITEMFILTERTYPE_TRAIT_ITEMS] = "Traits",
-    }
-
     --make sure all necessary information is present
     if filterInformation == nil then
         d("No filter information provided. Filter not registered.")
@@ -845,13 +1240,12 @@ function AdvancedFilters_RegisterFilter(filterInformation)
     end
 
     --get filter information from the calling addon and insert it into our callback table
-    local addonInformation = {
-        submenuName = filterInformation.submenuName,
-        callbackTable = filterInformation.callbackTable,
-        subfilters = filterInformation.subfilters,
-        generator = filterInformation.generator,
-    }
+    local addonInformation = BuildAddonInformation(filterInformation)
     local groupName = filterTypeToGroupName[filterInformation.filterType]
+
+    --Check if the same addon information is already in the callback tables for the filterType
+    --and remove the old one, before adding the same/newer one again
+    AdvancedFilters_RemoveDuplicateAddonPlugin(filterInformation, groupName)
 
     --insert addon information
     table.insert(AF.subfilterCallbacks[groupName].addonDropdownCallbacks, addonInformation)
@@ -860,15 +1254,13 @@ function AdvancedFilters_RegisterFilter(filterInformation)
     if filterInformation.generator then return end
 
     --get string information from the calling addon and insert it into our string table
-    local function addStrings(lang, strings)
+    --and support setmetatable!
+    --> Overwrite exisiting strings with data from the same AF plugin strings, if re-apllied
+    local function addStrings(lang, strings, langStrings)
         for key, string in pairs(strings) do
-            AF.strings[key] = string
+            AF.strings[key] = langStrings and langStrings[key] or string
         end
     end
     local lang = AF.util.GetLanguage()
-    if filterInformation[lang .. "Strings"] ~= nil then
-        addStrings(lang, filterInformation[lang .. "Strings"])
-    else
-        addStrings("en", filterInformation.enStrings)
-    end
+    addStrings(lang, filterInformation.enStrings, filterInformation[lang .. "Strings"])
 end

--- a/main.lua
+++ b/main.lua
@@ -1,56 +1,219 @@
-AdvancedFilters = {}
+if AdvancedFilters == nil then AdvancedFilters = {} end
 local AF = AdvancedFilters
 
+--Get the current maximum itemfiltertye
+AF.maxItemFilterType = ITEMFILTERTYPE_MAX_VALUE -- 25 is the maximum at API 100023 "Summerset"
+--Build new "virtual" itemfiltertype for weapons + armor at blacksmith station.
+--Needs the normal itemfiltertype_armor/weapon value "on-top" in order to get the change of
+--a tab at the crafting station (ChangeFilter function) working.
+--To distinguish the different crafting stations we need to add the TradeskillType number too
+ITEMFILTERTYPE_AF_WEAPONS_SMITHING      = AF.maxItemFilterType + ITEMFILTERTYPE_WEAPONS + CRAFTING_TYPE_BLACKSMITHING
+ITEMFILTERTYPE_AF_WEAPONS_WOODWORKING   = AF.maxItemFilterType + ITEMFILTERTYPE_WEAPONS + CRAFTING_TYPE_WOODWORKING
+ITEMFILTERTYPE_AF_ARMOR_SMITHING        = AF.maxItemFilterType + ITEMFILTERTYPE_ARMOR + CRAFTING_TYPE_BLACKSMITHING
+ITEMFILTERTYPE_AF_ARMOR_CLOTHIER        = AF.maxItemFilterType + ITEMFILTERTYPE_ARMOR + CRAFTING_TYPE_CLOTHIER
+ITEMFILTERTYPE_AF_ARMOR_WOODWORKING     = AF.maxItemFilterType + ITEMFILTERTYPE_ARMOR + CRAFTING_TYPE_WOODWORKING
+ITEMFILTERTYPE_AF_RUNES_ENCHANTING      = AF.maxItemFilterType + ITEMFILTERTYPE_ENCHANTING + ENCHANTING_MODE_CREATION + CRAFTING_TYPE_ENCHANTING
+ITEMFILTERTYPE_AF_GLYPHS_ENCHANTING     = AF.maxItemFilterType + ITEMFILTERTYPE_ENCHANTING + ENCHANTING_MODE_EXTRACTION + CRAFTING_TYPE_ENCHANTING
+ITEMFILTERTYPE_AF_JEWELRY_CRAFTING      = AF.maxItemFilterType + ITEMFILTERTYPE_JEWELRYCRAFTING + SMITHING_FILTER_TYPE_JEWELRY + CRAFTING_TYPE_JEWELRYCRAFTING
+ITEMFILTERTYPE_AF_JEWELRY_REFINE        = AF.maxItemFilterType + ITEMFILTERTYPE_JEWELRYCRAFTING + SMITHING_FILTER_TYPE_JEWELRY + CRAFTING_TYPE_JEWELRYCRAFTING + ITEMTYPE_JEWELRYCRAFTING_RAW_MATERIAL
+
+ITEMFILTERTYPE_AF_JEWELRY       = AF.maxItemFilterType + ITEMFILTERTYPE_JEWELRYCRAFTING + SMITHING_FILTER_TYPE_JEWELRY + CRAFTING_TYPE_JEWELRYCRAFTING
+ITEMFILTERTYPE_AF_REFINE_SMITHING       = AF.maxItemFilterType + ITEMFILTERTYPE_CRAFTING + CRAFTING_TYPE_BLACKSMITHING
+ITEMFILTERTYPE_AF_REFINE_CLOTHIER       = AF.maxItemFilterType + ITEMFILTERTYPE_CRAFTING + CRAFTING_TYPE_CLOTHIER
+ITEMFILTERTYPE_AF_REFINE_WOODWORKING    = AF.maxItemFilterType + ITEMFILTERTYPE_CRAFTING + CRAFTING_TYPE_WOODWORKING
+
+--Get the current maximum inventory types and add 1 for the vendor buy inv type
+INVENTORY_TYPE_VENDOR_BUY = 100
+
 AF.subfilterGroups = {
+    --Player inventory
     [INVENTORY_BACKPACK] = {
-        [ITEMFILTERTYPE_ALL] = {},
-        [ITEMFILTERTYPE_WEAPONS] = {},
-        [ITEMFILTERTYPE_ARMOR] = {},
-        [ITEMFILTERTYPE_CONSUMABLE] = {},
-        [ITEMFILTERTYPE_CRAFTING] = {},
-        [ITEMFILTERTYPE_FURNISHING] = {},
-        [ITEMFILTERTYPE_MISCELLANEOUS] = {},
-        --[ITEMFILTERTYPE_JUNK] = {},
+        [CRAFTING_TYPE_INVALID] = {
+            [ITEMFILTERTYPE_ALL] = {},
+            [ITEMFILTERTYPE_WEAPONS] = {},
+            [ITEMFILTERTYPE_ARMOR] = {},
+            [ITEMFILTERTYPE_JEWELRY] = {},          -- new with Summersend
+            [ITEMFILTERTYPE_JEWELRYCRAFTING] = {},  -- new with Summersend
+            [ITEMFILTERTYPE_CONSUMABLE] = {},
+            [ITEMFILTERTYPE_CRAFTING] = {},
+            [ITEMFILTERTYPE_FURNISHING] = {},
+            [ITEMFILTERTYPE_MISCELLANEOUS] = {},
+            --[ITEMFILTERTYPE_JUNK] = {},
+        },
     },
+    --Bank
     [INVENTORY_BANK] = {
-        [ITEMFILTERTYPE_ALL] = {},
-        [ITEMFILTERTYPE_WEAPONS] = {},
-        [ITEMFILTERTYPE_ARMOR] = {},
-        [ITEMFILTERTYPE_CONSUMABLE] = {},
-        [ITEMFILTERTYPE_CRAFTING] = {},
-        [ITEMFILTERTYPE_FURNISHING] = {},
-        [ITEMFILTERTYPE_MISCELLANEOUS] = {},
-        --[ITEMFILTERTYPE_JUNK] = {},
+        [CRAFTING_TYPE_INVALID] = {
+            [ITEMFILTERTYPE_ALL] = {},
+            [ITEMFILTERTYPE_WEAPONS] = {},
+            [ITEMFILTERTYPE_ARMOR] = {},
+            [ITEMFILTERTYPE_JEWELRY] = {},          -- new with Summersend
+            [ITEMFILTERTYPE_JEWELRYCRAFTING] = {},  -- new with Summersend
+            [ITEMFILTERTYPE_CONSUMABLE] = {},
+            [ITEMFILTERTYPE_CRAFTING] = {},
+            [ITEMFILTERTYPE_FURNISHING] = {},
+            [ITEMFILTERTYPE_MISCELLANEOUS] = {},
+            --[ITEMFILTERTYPE_JUNK] = {},
+        },
     },
+    --Guild bank
     [INVENTORY_GUILD_BANK] = {
-        [ITEMFILTERTYPE_ALL] = {},
-        [ITEMFILTERTYPE_WEAPONS] = {},
-        [ITEMFILTERTYPE_ARMOR] = {},
-        [ITEMFILTERTYPE_CONSUMABLE] = {},
-        [ITEMFILTERTYPE_CRAFTING] = {},
-        [ITEMFILTERTYPE_FURNISHING] = {},
-        [ITEMFILTERTYPE_MISCELLANEOUS] = {},
-        --[ITEMFILTERTYPE_JUNK] = {},
+        [CRAFTING_TYPE_INVALID] = {
+            [ITEMFILTERTYPE_ALL] = {},
+            [ITEMFILTERTYPE_WEAPONS] = {},
+            [ITEMFILTERTYPE_ARMOR] = {},
+            [ITEMFILTERTYPE_JEWELRY] = {},          -- new with Summersend
+            [ITEMFILTERTYPE_JEWELRYCRAFTING] = {},  -- new with Summersend
+            [ITEMFILTERTYPE_CONSUMABLE] = {},
+            [ITEMFILTERTYPE_CRAFTING] = {},
+            [ITEMFILTERTYPE_FURNISHING] = {},
+            [ITEMFILTERTYPE_MISCELLANEOUS] = {},
+            --[ITEMFILTERTYPE_JUNK] = {},
+        },
     },
+    --Craft bag
     [INVENTORY_CRAFT_BAG] = {
-        [ITEMFILTERTYPE_ALL] = {},
-        [ITEMFILTERTYPE_BLACKSMITHING] = {},
-        [ITEMFILTERTYPE_CLOTHING] = {},
-        [ITEMFILTERTYPE_WOODWORKING] = {},
-        [ITEMFILTERTYPE_ALCHEMY] = {},
-        [ITEMFILTERTYPE_ENCHANTING] = {},
-        [ITEMFILTERTYPE_PROVISIONING] = {},
-        [ITEMFILTERTYPE_STYLE_MATERIALS] = {},
-        [ITEMFILTERTYPE_TRAIT_ITEMS] = {},
+        [CRAFTING_TYPE_INVALID] = {
+            [ITEMFILTERTYPE_ALL] = {},
+            [ITEMFILTERTYPE_BLACKSMITHING] = {},
+            [ITEMFILTERTYPE_CLOTHING] = {},
+            [ITEMFILTERTYPE_WOODWORKING] = {},
+            [ITEMFILTERTYPE_ALCHEMY] = {},
+            [ITEMFILTERTYPE_ENCHANTING] = {},
+            [ITEMFILTERTYPE_PROVISIONING] = {},
+            [ITEMFILTERTYPE_JEWELRYCRAFTING] = {},  -- new with Summersend
+            [ITEMFILTERTYPE_STYLE_MATERIALS] = {},
+            [ITEMFILTERTYPE_TRAIT_ITEMS] = {},
+        },
     },
-    [6] = {
-        [ITEMFILTERTYPE_ALL] = {},
-        [ITEMFILTERTYPE_WEAPONS] = {},
-        [ITEMFILTERTYPE_ARMOR] = {},
-        [ITEMFILTERTYPE_CONSUMABLE] = {},
-        [ITEMFILTERTYPE_CRAFTING] = {},
-        [ITEMFILTERTYPE_MISCELLANEOUS] = {},
-    }, --VENDOR_SELL
+    --Vendor buy
+    [INVENTORY_TYPE_VENDOR_BUY] = {
+        [CRAFTING_TYPE_INVALID] = {
+            [ITEMFILTERTYPE_ALL] = {},
+            [ITEMFILTERTYPE_WEAPONS] = {},
+            [ITEMFILTERTYPE_ARMOR] = {},
+            [ITEMFILTERTYPE_CONSUMABLE] = {},
+            [ITEMFILTERTYPE_CRAFTING] = {},
+            [ITEMFILTERTYPE_MISCELLANEOUS] = {},
+        },
+    },
+
+    --Crafting SMITHING: Refine
+    [LF_SMITHING_REFINE] = {
+        [CRAFTING_TYPE_BLACKSMITHING] = {
+            [ITEMFILTERTYPE_ALL] = {},
+            [ITEMFILTERTYPE_AF_REFINE_SMITHING] = {},
+        },
+        [CRAFTING_TYPE_WOODWORKING] = {
+            [ITEMFILTERTYPE_ALL] = {},
+            [ITEMFILTERTYPE_AF_REFINE_WOODWORKING] = {},
+        },
+        [CRAFTING_TYPE_CLOTHIER] = {
+            [ITEMFILTERTYPE_ALL] = {},
+            [ITEMFILTERTYPE_AF_REFINE_CLOTHIER] = {},
+        },
+    },
+
+    --Crafting SMITHING: Deconstruction
+    [LF_SMITHING_DECONSTRUCT] = {
+        [CRAFTING_TYPE_BLACKSMITHING] = {
+            [ITEMFILTERTYPE_ALL] = {},
+            [ITEMFILTERTYPE_AF_WEAPONS_SMITHING] = {},
+            [ITEMFILTERTYPE_AF_ARMOR_SMITHING] = {},
+        },
+        [CRAFTING_TYPE_WOODWORKING] = {
+            [ITEMFILTERTYPE_ALL] = {},
+            [ITEMFILTERTYPE_AF_WEAPONS_WOODWORKING] = {},
+            [ITEMFILTERTYPE_AF_ARMOR_WOODWORKING] = {},
+        },
+        [CRAFTING_TYPE_CLOTHIER] = {
+            [ITEMFILTERTYPE_ALL] = {},
+            [ITEMFILTERTYPE_AF_ARMOR_CLOTHIER] = {},
+        },
+        --[[
+        [CRAFTING_TYPE_JEWELRYCRAFTING] = {
+            [ITEMFILTERTYPE_ALL] = {},
+            [ITEMFILTERTYPE_AF_JEWELRY_CRAFTING] = {},
+        },
+        ]]
+    },
+
+    --Crafting SMITHING: Improvement
+    [LF_SMITHING_IMPROVEMENT] = {
+        [CRAFTING_TYPE_BLACKSMITHING] = {
+            [ITEMFILTERTYPE_ALL] = {},
+            [ITEMFILTERTYPE_AF_WEAPONS_SMITHING] = {},
+            [ITEMFILTERTYPE_AF_ARMOR_SMITHING] = {},
+        },
+        [CRAFTING_TYPE_WOODWORKING] = {
+            [ITEMFILTERTYPE_ALL] = {},
+            [ITEMFILTERTYPE_AF_WEAPONS_WOODWORKING] = {},
+            [ITEMFILTERTYPE_AF_ARMOR_WOODWORKING] = {},
+        },
+        [CRAFTING_TYPE_CLOTHIER] = {
+            [ITEMFILTERTYPE_ALL] = {},
+            [ITEMFILTERTYPE_AF_ARMOR_CLOTHIER] = {},
+        },
+        --[[
+        [CRAFTING_TYPE_JEWELRYCRAFTING] = {
+            [ITEMFILTERTYPE_ALL] = {},
+            [ITEMFILTERTYPE_AF_JEWELRY_CRAFTING] = {},
+        },
+        ]]
+    },
+
+    --Crafting JEWELRY: Refine
+    [LF_JEWELRY_REFINE] = {
+        [CRAFTING_TYPE_JEWELRYCRAFTING] = {
+            [ITEMFILTERTYPE_ALL] = {},
+            [ITEMFILTERTYPE_AF_JEWELRY_REFINE] = {},
+        },
+    },
+
+    --Crafting JEWELRY: Deconstruction
+    [LF_JEWELRY_DECONSTRUCT] = {
+        [CRAFTING_TYPE_JEWELRYCRAFTING] = {
+            [ITEMFILTERTYPE_ALL] = {},
+            [ITEMFILTERTYPE_AF_JEWELRY_CRAFTING] = {},
+        },
+    },
+    --Crafting JEWELRY: Improvement
+    [LF_JEWELRY_IMPROVEMENT] = {
+        [CRAFTING_TYPE_JEWELRYCRAFTING] = {
+            [ITEMFILTERTYPE_ALL] = {},
+            [ITEMFILTERTYPE_AF_JEWELRY_CRAFTING] = {},
+        },
+    },
+
+    --Crafting ENCHANTING: Creation
+    [LF_ENCHANTING_CREATION] = {
+        [CRAFTING_TYPE_ENCHANTING] = {
+            [ITEMFILTERTYPE_ALL] = {},
+            --[ITEMFILTERTYPE_AF_RUNES_ENCHANTING] = {}, TODO: Currently disabled as no extra filters are needed/possible
+        },
+    },
+    --Crafting ENCHANTING: Extraction
+    [LF_ENCHANTING_EXTRACTION] = {
+        [CRAFTING_TYPE_ENCHANTING] = {
+            [ITEMFILTERTYPE_ALL] = {},
+            [ITEMFILTERTYPE_AF_GLYPHS_ENCHANTING] = {},
+        },
+    },
+    --Houes bank withdraw
+    [INVENTORY_HOUSE_BANK] = {
+        [CRAFTING_TYPE_INVALID] = {
+            [ITEMFILTERTYPE_ALL] = {},
+            [ITEMFILTERTYPE_WEAPONS] = {},
+            [ITEMFILTERTYPE_ARMOR] = {},
+            [ITEMFILTERTYPE_CONSUMABLE] = {},
+            [ITEMFILTERTYPE_CRAFTING] = {},
+            [ITEMFILTERTYPE_FURNISHING] = {},
+            [ITEMFILTERTYPE_MISCELLANEOUS] = {},
+            --[ITEMFILTERTYPE_JUNK] = {},
+            [ITEMFILTERTYPE_JEWELRY] = {},          -- new with Summersend
+            [ITEMFILTERTYPE_JEWELRYCRAFTING] = {},  -- new with Summersend
+        },
+    },
 }
 
 AF.currentInventoryType = INVENTORY_BACKPACK
@@ -85,10 +248,12 @@ local function InitializeHooks()
             --refresh subfilters for inventory type
             local subfilterGroup = AF.subfilterGroups[k]
             if not subfilterGroup then return end
+            local craftingType = AF.util.GetCraftingType()
+            local invType = AF.currentInventoryType
             local currentSubfilterBar = subfilterGroup.currentSubfilterBar
             if not currentSubfilterBar then return end
 
-            AF.util.ThrottledUpdate("RefreshSubfilterBar" .. currentSubfilterBar.name, 10, AF.util.RefreshSubfilterBar, currentSubfilterBar)
+            AF.util.ThrottledUpdate("RefreshSubfilterBarMetaTable_" .. invType .. "_" .. craftingType .. currentSubfilterBar.name, 10, AF.util.RefreshSubfilterBar, currentSubfilterBar)
         end,
     }
     --tracking function. Returns a proxy table with our metatable attached.
@@ -105,11 +270,45 @@ local function InitializeHooks()
         return t
     end
 
-    local function ShowSubfilterBar(currentFilter)
+    --As some inventories/panels use the same parents to anchor the subfilter bars to
+    --the change of the panel won't change the parent and thus doesn't hide the subfilter
+    --bars properly.
+    --Example: ENCHANTING creation & extraction, deconstruction/improvement for woodworking/blacksmithing/clothing & jewelry deconstruction/improvement
+    --This function checks the inventory type and hides the old subfilterbar if needed.
+    local function hideSubfilterBarSameParent(inventoryType)
+--d("[AF]hideSubfilterBarSameParent - inventoryType: " .. inventoryType)
+        if not inventoryType then return end
+        local mapInvTypeToInvTypeBefore = {
+            --Enchanting
+            [LF_ENCHANTING_CREATION]    = LF_ENCHANTING_EXTRACTION,
+            [LF_ENCHANTING_EXTRACTION]  = LF_ENCHANTING_CREATION,
+            --Refinement
+            [LF_SMITHING_REFINE]        = LF_JEWELRY_REFINE,
+            [LF_JEWELRY_REFINE]         = LF_SMITHING_REFINE,
+            --Deconstruction
+            [LF_SMITHING_DECONSTRUCT]   = LF_JEWELRY_DECONSTRUCT,
+            [LF_JEWELRY_DECONSTRUCT]    = LF_SMITHING_DECONSTRUCT,
+            --Improvement
+            [LF_SMITHING_IMPROVEMENT]   = LF_JEWELRY_IMPROVEMENT,
+            [LF_JEWELRY_IMPROVEMENT]    = LF_SMITHING_IMPROVEMENT,
+        }
+        if mapInvTypeToInvTypeBefore[inventoryType] == nil then return false end
+        local invTypeBefore = mapInvTypeToInvTypeBefore[inventoryType]
+        if not invTypeBefore then return end
+        local subfilterGroupBefore = AF.subfilterGroups[invTypeBefore]
+        if subfilterGroupBefore ~= nil and subfilterGroupBefore.currentSubfilterBar then
+            subfilterGroupBefore.currentSubfilterBar:SetHidden(true)
+        end
+    end
+
+    local function ShowSubfilterBar(currentFilter, craftingType)
+        if craftingType == nil then craftingType = AF.util.GetCraftingType() end
+--d("[AF]]ShowSubfilterBar - currentFilter: " .. tostring(currentFilter) .. ", craftingType: " .. tostring(craftingType) .. ", invType: " .. tostring(AF.currentInventoryType))
         local function UpdateListAnchors(self, shiftY)
+--d(">UpdateListAnchors - shiftY: " .. tostring(shiftY))
+            if self == nil then return end
             local layoutData = self.appliedLayout or BACKPACK_DEFAULT_LAYOUT_FRAGMENT.layoutData
             if not layoutData then return end
-
             local list = self.list or self.inventories[AF.currentInventoryType].listView
             list:SetWidth(layoutData.width)
             list:ClearAnchors()
@@ -126,25 +325,45 @@ local function InitializeHooks()
 
         --get new bar
         local subfilterGroup = AF.subfilterGroups[AF.currentInventoryType]
-        local subfilterBar = subfilterGroup[currentFilter]
+        local subfilterBar = subfilterGroup[craftingType][currentFilter]
 
         --hide old bar, if it exists
         if subfilterGroup.currentSubfilterBar ~= nil then
+--d(">hiding current/old subfilterbar")
             subfilterGroup.currentSubfilterBar:SetHidden(true)
         end
+        --hide old bar at same parent
+        hideSubfilterBarSameParent(AF.currentInventoryType)
 
         --do nothing if we're in a guild store and regular filters are disabled.
         if not ZO_TradingHouse:IsHidden() and AF.util.libCIF._guildStoreSellFiltersDisabled then return end
+
+        --Crafting
+        local craftingInv
+        local isCraftingInventoryType = false
+        if AF.util.IsCraftingPanelShown() then
+--d(">crafting subfilterbar shown")
+            isCraftingInventoryType = AF.util.IsCraftingStationInventoryType(subfilterBar.inventoryType)
+            if isCraftingInventoryType then
+                craftingInv = AF.util.GetInventoryFromCraftingPanel(subfilterBar.inventoryType)
+            end
+        end
 
         --if new bar exists
         if subfilterBar then
             --set current bar reference
             subfilterGroup.currentSubfilterBar = subfilterBar
 
+--d(">subfilterBar exists, name: " .. tostring(subfilterBar.control:GetName()) .. ",  inventoryType: " ..tostring(subfilterBar.inventoryType))
+
             --set currentFilter since we need it before the original ChangeFilter updates it
-            if subfilterBar.inventoryType == 6 then
+            if subfilterBar.inventoryType == INVENTORY_TYPE_VENDOR_BUY then
                 STORE_WINDOW.currentFilter = currentFilter
+            elseif isCraftingInventoryType then
+--d("> Set currentfilter to: " .. currentFilter)
+                craftingInv.currentFilter = currentFilter
             else
+--d(">player inv. subfilterbar")
                 PLAYER_INVENTORY.inventories[subfilterBar.inventoryType].currentFilter = currentFilter
             end
 
@@ -155,8 +374,11 @@ local function InitializeHooks()
             subfilterBar:SetHidden(false)
 
             --set proper inventory anchor displacement
-            if subfilterBar.inventoryType == 6 then
+            if subfilterBar.inventoryType == INVENTORY_TYPE_VENDOR_BUY then
                 UpdateListAnchors(STORE_WINDOW, subfilterBar.control:GetHeight())
+            elseif isCraftingInventoryType then
+--d("> UpdateListAnchors - Crafting")
+                UpdateListAnchors(craftingInv, subfilterBar.control:GetHeight())
             else
                 UpdateListAnchors(PLAYER_INVENTORY, subfilterBar.control:GetHeight())
             end
@@ -165,8 +387,10 @@ local function InitializeHooks()
             AF.util.RemoveAllFilters()
 
             --set original inventory anchor displacement
-            if AF.currentInventoryType == 6 then
+            if AF.currentInventoryType == INVENTORY_TYPE_VENDOR_BUY then
                 UpdateListAnchors(STORE_WINDOW, 0)
+            elseif isCraftingInventoryType then
+                UpdateListAnchors(craftingInv, 0)
             else
                 UpdateListAnchors(PLAYER_INVENTORY, 0)
             end
@@ -181,7 +405,7 @@ local function InitializeHooks()
         local function onFragmentShowing()
             AF.currentInventoryType = inventoryType
 
-            if inventoryType == 6 then
+            if inventoryType == INVENTORY_TYPE_VENDOR_BUY then
                 AF.util.ThrottledUpdate("ShowSubfilterBar" .. inventoryType, 10,
                   ShowSubfilterBar, STORE_WINDOW.currentFilter)
             else
@@ -195,6 +419,9 @@ local function InitializeHooks()
 
         local function onFragmentHiding()
             PLAYER_INVENTORY.isListDirty = untrack(PLAYER_INVENTORY.isListDirty)
+
+            --Reset the current inventory type to the normal inventory
+            AF.currentInventoryType = INVENTORY_BACKPACK
         end
 
         local function onFragmentStateChange(oldState, newState)
@@ -209,148 +436,589 @@ local function InitializeHooks()
     end
     hookFragment(INVENTORY_FRAGMENT, INVENTORY_BACKPACK)
     hookFragment(BANK_FRAGMENT, INVENTORY_BANK)
-    hookFragment(GUILD_BANK_FRAGMENT, INVENTORY_GUILD_BANK)
-    hookFragment(CRAFT_BAG_FRAGMENT, INVENTORY_CRAFT_BAG)
-    hookFragment(STORE_FRAGMENT, 6)
+    hookFragment(HOUSE_BANK_FRAGMENT, INVENTORY_HOUSE_BANK)
+    hookFragment(GUILD_BANK_FRAGMENT, INVENTORY_GUILD_BANK) -- new value is: 5
+    hookFragment(CRAFT_BAG_FRAGMENT, INVENTORY_CRAFT_BAG) -- new value is: 6
+    hookFragment(STORE_FRAGMENT, INVENTORY_TYPE_VENDOR_BUY)
+
+    --Hook the crafting station
+    --SMITHING
+    local function HookSmithingSetMode(self, mode)
+        --if not AF.util.IsCraftingPanelShown() then return false end
+        --[[
+            --Smithing modes
+            SMITHING_MODE_ROOT = 0
+            SMITHING_MODE_REFINMENT = 1
+            SMITHING_MODE_CREATION = 2
+            SMITHING_MODE_DECONSTRUCTION = 3
+            SMITHING_MODE_IMPROVEMENT = 4
+            SMITHING_MODE_RESEARCH = 5
+            SMITHING_MODE_RECIPES = 6
+        ]]
+        local craftType = GetCraftingInteractionType()
+        local isJewelryCrafting = (craftType == CRAFTING_TYPE_JEWELRYCRAFTING) or false
+        if     mode == SMITHING_MODE_REFINEMENT then
+            if isJewelryCrafting then
+                AF.currentInventoryType = LF_JEWELRY_REFINE
+            else
+                AF.currentInventoryType = LF_SMITHING_REFINE
+            end
+        elseif     mode == SMITHING_MODE_CREATION then
+            if isJewelryCrafting then
+                AF.currentInventoryType = LF_JEWELRY_CREATION
+            else
+                AF.currentInventoryType = LF_SMITHING_CREATION
+            end
+        elseif     mode == SMITHING_MODE_DECONSTRUCTION then
+            if isJewelryCrafting then
+                AF.currentInventoryType = LF_JEWELRY_DECONSTRUCT
+            else
+                AF.currentInventoryType = LF_SMITHING_DECONSTRUCT
+            end
+        elseif mode == SMITHING_MODE_IMPROVEMENT then
+            if isJewelryCrafting then
+                AF.currentInventoryType = LF_JEWELRY_IMPROVEMENT
+            else
+                AF.currentInventoryType = LF_SMITHING_IMPROVEMENT
+            end
+        end
+        return false
+    end
+    --ZO_PreHook(ZO_Smithing, "SetMode", HookSmithingSetMode)
+    local origSmithingSetMode = ZO_Smithing.SetMode
+    ZO_Smithing.SetMode = function(...)
+        origSmithingSetMode(...)
+        HookSmithingSetMode(...)
+    end
+
+    --ENCHANTING
+    local function HookEnchantingSetEnchantingMode(self, mode)
+--d("[AF]HookEnchantingSetEnchantingMode, mode: " .. tostring(mode))
+        --if not AF.util.IsCraftingPanelShown() then return false end
+        --[[
+            --Enchanting modes
+            ENCHANTING_MODE_CREATION = 1
+            ENCHANTING_MODE_EXTRACTION = 2
+            ENCHANTING_MODE_NONE = 0
+        ]]
+        if     mode == ENCHANTING_MODE_CREATION then
+            AF.currentInventoryType = LF_ENCHANTING_CREATION
+        elseif mode == ENCHANTING_MODE_EXTRACTION then
+            AF.currentInventoryType = LF_ENCHANTING_EXTRACTION
+        end
+        return false
+    end
+    --ZO_PreHook(ZO_Enchanting, "SetEnchantingMode", HookEnchantingSetEnchantingMode)
+    local origEnchantingSetEnchantMode = ZO_Enchanting.SetEnchantingMode
+    ZO_Enchanting.SetEnchantingMode = function(...)
+        origEnchantingSetEnchantMode(...)
+        HookEnchantingSetEnchantingMode(...)
+    end
 
     --PREHOOKS
     local function ChangeFilterInventory(self, filterTab)
+--d("[AF]PLAYER_INVENTORY:ChangeFilter")
         local currentFilter = self:GetTabFilterInfo(filterTab.inventoryType, filterTab)
-
-        if AF.currentInventoryType ~= 6 then
+        if AF.currentInventoryType ~= INVENTORY_TYPE_VENDOR_BUY then
             AF.util.ThrottledUpdate(
               "ShowSubfilterBar" .. AF.currentInventoryType, 10,
               ShowSubfilterBar, currentFilter)
         end
+        --Update the totat count for quest and junk items as there are no epxlicit filterBars available until today!
+        if filterTab.inventoryType == INVENTORY_QUEST_ITEM          --Quest items
+            or filterTab.filterType == ITEMFILTERTYPE_JUNK then     --Junk items
+            --Update the count of filtered/shown items in the inventory FreeSlot label
+            --Delay this function call as the data needs to be filtered first!
+            local invType
+            if filterTab.inventoryType == INVENTORY_QUEST_ITEM then
+                invType = INVENTORY_QUEST_ITEM
+            else
+                invType = AF.currentInventoryType
+            end
+            zo_callLater(function()
+                AF.util.updateInventoryInfoBarCountLabel(invType)
+            end, 50)
+        end
     end
     ZO_PreHook(PLAYER_INVENTORY, "ChangeFilter", ChangeFilterInventory)
+
     local function ChangeFilterVendor(self, filterTab)
         local currentFilter = filterTab.filterType
 
-        AF.util.ThrottledUpdate("ShowSubfilterBar6", 10, ShowSubfilterBar,
+        AF.util.ThrottledUpdate("ShowSubfilterBar" .. tostring(INVENTORY_TYPE_VENDOR_BUY), 10, ShowSubfilterBar,
           currentFilter)
 
-        local subfilterGroup = AF.subfilterGroups[6]
+        local invType = INVENTORY_TYPE_VENDOR_BUY -- AF.currentInventoryType
+        local subfilterGroup = AF.subfilterGroups[invType]
         if not subfilterGroup then return end
+        local craftingType = AF.util.GetCraftingType()
         local currentSubfilterBar = subfilterGroup.currentSubfilterBar
         if not currentSubfilterBar then return end
 
-        AF.util.ThrottledUpdate("RefreshSubfilterBar" .. currentSubfilterBar.name, 10,
+        AF.util.ThrottledUpdate("RefreshSubfilterBar" .. invType .. "_" .. craftingType .. currentSubfilterBar.name, 10,
           AF.util.RefreshSubfilterBar, currentSubfilterBar)
     end
     ZO_PreHook(STORE_WINDOW, "ChangeFilter", ChangeFilterVendor)
+
+    local function ChangeFilterCrafting(self, filterTab)
+        zo_callLater(function()
+            local invType = AF.currentInventoryType
+            local craftingType = AF.util.GetCraftingType()
+            local currentFilter = AF.util.MapCraftingStationFilterType2ItemFilterType(self.filterType, invType, craftingType)
+
+            AF.util.ThrottledUpdate("ShowSubfilterBar" .. invType .. "_" .. craftingType, 10,
+                ShowSubfilterBar, currentFilter, craftingType)
+
+            local subfilterGroup = AF.subfilterGroups[invType]
+            if not subfilterGroup then return end
+            local currentSubfilterBar = subfilterGroup.currentSubfilterBar
+            if not currentSubfilterBar then return end
+
+            AF.util.ThrottledUpdate("RefreshSubfilterBar" .. invType .. "_" .. craftingType .. currentSubfilterBar.name, 10,
+                AF.util.RefreshSubfilterBar, currentSubfilterBar)
+        end, 10) -- called with small delay, otherwise self.filterType is nil
+    end
+    ZO_PreHook(SMITHING.refinementPanel.inventory, "ChangeFilter", ChangeFilterCrafting)
+    ZO_PreHook(SMITHING.deconstructionPanel.inventory, "ChangeFilter", ChangeFilterCrafting)
+    ZO_PreHook(SMITHING.improvementPanel.inventory, "ChangeFilter", ChangeFilterCrafting)
+
+    local function ChangeFilterEnchanting(self, filterTab)
+        zo_callLater(function()
+            local invType = AF.currentInventoryType
+            local craftingType = AF.util.GetCraftingType()
+            local currentFilter = AF.util.MapCraftingStationFilterType2ItemFilterType(self.owner.enchantingMode, invType, craftingType)
+--d("[AF]ChangeFilterEnchanting - currentFilter: " ..tostring(currentFilter) .. ", currentInventoryType: " .. tostring(invType) .. ", craftingType: " ..tostring(craftingType))
+            --Only show subfilters at the enchanting extraction panel
+            AF.util.ThrottledUpdate("ShowSubfilterBar" .. invType .. "_" .. craftingType, 10,
+                ShowSubfilterBar, currentFilter, craftingType)
+            local subfilterGroup = AF.subfilterGroups[invType]
+            if not subfilterGroup then return end
+            local currentSubfilterBar = subfilterGroup.currentSubfilterBar
+            if not currentSubfilterBar then return end
+
+            AF.util.ThrottledUpdate("RefreshSubfilterBar" .. invType .. "_" .. craftingType .. currentSubfilterBar.name, 10,
+                AF.util.RefreshSubfilterBar, currentSubfilterBar)
+        end, 10) -- called with small delay, otherwise self.filterType is nil
+    end
+    ZO_PreHook(ENCHANTING.inventory, "ChangeFilter", ChangeFilterEnchanting)
+
+    --Overwrite the standard inventory update function for the used slots/totla slots
+    local function hookInventoryInfoBar()
+        local colorString = "|cFFA500"	-- dark orange color
+        --local invInfoBar = PLAYER_INVENTORY:GetContextualInfoBar()
+        --if invInfoBar == nil then return nil end
+        --Overwrite the updte function for the free slots label in inventories
+        function ZO_InventoryManager:UpdateFreeSlots(inventoryType)
+--d("[AF]ZO_InventoryManager:UpdateFreeSlots, inventoryType: " ..tostring(inventoryType))
+            local inventory = self.inventories[inventoryType]
+            local freeSlotType
+            local altFreeSlotType
+
+            --Quest items "hack" to update the count label here too
+            if inventoryType == INVENTORY_QUEST_ITEM then
+                local copyFreeSlotsInfoFromInv = INVENTORY_BACKPACK
+                inventory.freeSlotsLabel    = self.inventories[copyFreeSlotsInfoFromInv].freeSlotsLabel
+                inventory.freeSlotType      = self.inventories[copyFreeSlotsInfoFromInv].freeSlotType
+                inventory.altFreeSlotsLabel = self.inventories[copyFreeSlotsInfoFromInv].altFreeSlotsLabel
+                inventory.altFreeSlotType   = self.inventories[copyFreeSlotsInfoFromInv].altFreeSlotType
+            end
+
+            if (type(inventory.freeSlotType) == "function") then
+                freeSlotType = inventory.freeSlotType()
+            else
+                freeSlotType = inventory.freeSlotType
+            end
+
+            if (type(inventory.altFreeSlotType) == "function") then
+                altFreeSlotType = inventory.altFreeSlotType()
+            else
+                altFreeSlotType = inventory.altFreeSlotType
+            end
+
+            local showFreeSlots    = inventory.freeSlotsLabel ~= nil
+            local showAltFreeSlots = (inventory.altFreeSlotsLabel ~= nil and altFreeSlotType ~= nil)
+
+            if showFreeSlots then
+                local freeSlotTypeInventory = self.inventories[freeSlotType]
+                local numUsedSlots, numSlots = self:GetNumSlots(freeSlotType)
+                if inventoryType == INVENTORY_QUEST_ITEM then freeSlotType = INVENTORY_QUEST_ITEM end
+                local numFilteredAndShownItems = AF.util.getInvItemCount(freeSlotType)
+                local freeSlotsShown = inventoryType == freeSlotType and numFilteredAndShownItems or 0
+                local freeSlotText = ""
+
+                if(numUsedSlots < numSlots) then
+                    freeSlotText = zo_strformat(freeSlotTypeInventory.freeSlotsStringId, numUsedSlots, numSlots)
+                else
+                    freeSlotText = zo_strformat(freeSlotTypeInventory.freeSlotsFullStringId, numUsedSlots, numSlots)
+                end
+                local newFreeSlotText
+                if freeSlotsShown > 0 then
+                    newFreeSlotText = zo_strformat("<<1>> <<2>>(<<3>>)", freeSlotText, colorString, freeSlotsShown) .. "|r"
+                else
+                    newFreeSlotText = freeSlotText
+                end
+                inventory.freeSlotsLabel:SetText(newFreeSlotText)
+            end
+
+            if showAltFreeSlots then
+                local numUsedSlots, numSlots = self:GetNumSlots(altFreeSlotType)
+                local altFreeSlotInventory = self.inventories[altFreeSlotType] --grab the alternateInventory to use it's string id's
+                local numFilteredAndShownItems = AF.util.getInvItemCount(altFreeSlotType)
+                local altFreeSlotsShown = inventoryType == altFreeSlotType and numFilteredAndShownItems or 0
+                local altFreeSlotText = ""
+
+                if(numUsedSlots < numSlots) then
+                    altFreeSlotText = zo_strformat(altFreeSlotInventory.freeSlotsStringId, numUsedSlots, numSlots)
+                else
+                    altFreeSlotText = zo_strformat(altFreeSlotInventory.freeSlotsFullStringId, numUsedSlots, numSlots)
+                end
+                local newAltFreeSlotText
+                if altFreeSlotsShown > 0 then
+                    newAltFreeSlotText = zo_strformat("<<1>> <<2>>(<<3>>)", altFreeSlotText, colorString, altFreeSlotsShown) .. "|r"
+                else
+                    newAltFreeSlotText = altFreeSlotText
+                end
+                inventory.altFreeSlotsLabel:SetText(newAltFreeSlotText)
+            end
+        end
+
+        function ZO_QuickslotManager:UpdateFreeSlots()
+
+            local numUsedSlots, numSlots = PLAYER_INVENTORY:GetNumSlots(INVENTORY_BACKPACK)
+            local numFilteredAndShownItems = #self.list.data
+            local freeSlotsShown = numFilteredAndShownItems or 0
+            local freeSlotText = ""
+            if(numUsedSlots < numSlots) then
+                freeSlotText = zo_strformat(SI_INVENTORY_BACKPACK_REMAINING_SPACES, numUsedSlots, numSlots)
+            else
+                freeSlotText = zo_strformat(SI_INVENTORY_BACKPACK_COMPLETELY_FULL, numUsedSlots, numSlots)
+            end
+            local newFreeSlotText
+            if freeSlotsShown > 0 then
+                newFreeSlotText = zo_strformat("<<1>> <<2>>(<<3>>)", freeSlotText, colorString, freeSlotsShown) .. "|r"
+            else
+                newFreeSlotText = freeSlotText
+            end
+            self.freeSlotsLabel:SetText(newFreeSlotText)
+        end
+
+        --Overwrite the function UpdateInventorySlots from esoui/esoui/ingame/inventory/inventorytemplates.lua
+        --for the crafting stations, in order to update the filter count amount properly in the infoBars
+        function UpdateInventorySlots(infoBar)
+--d("[AF]UpdateInventorySlots: " .. tostring(infoBar:GetName()))
+            --Only for crafting station inventory types as the others are managed within function ZO_InventoryManager:UpdateFreeSlots(inventoryType) above!
+            local invType = AF.currentInventoryType
+            local isCraftingInvType = AF.util.IsCraftingStationInventoryType(invType)
+            if not isCraftingInvType then return false end
+
+            local slotsLabel = infoBar:GetNamedChild("FreeSlots")
+            local numUsedSlots, numSlots = PLAYER_INVENTORY:GetNumSlots(INVENTORY_BACKPACK)
+            local numFilteredAndShownItems = AF.util.getInvItemCount(invType, isCraftingInvType)
+            local freeSlotsShown = ((numFilteredAndShownItems > 0) and numFilteredAndShownItems) or 0
+            local freeSlotText = ""
+            if numUsedSlots < numSlots then
+                freeSlotText = zo_strformat(SI_INVENTORY_BACKPACK_REMAINING_SPACES, numUsedSlots, numSlots)
+            else
+                freeSlotText = zo_strformat(SI_INVENTORY_BACKPACK_COMPLETELY_FULL, numUsedSlots, numSlots)
+            end
+            local newFreeSlotText
+            if freeSlotsShown > 0 then
+                newFreeSlotText = zo_strformat("<<1>> <<2>>(<<3>>)", freeSlotText, colorString, freeSlotsShown) .. "|r"
+            else
+                newFreeSlotText = freeSlotText
+            end
+            slotsLabel:SetText(newFreeSlotText)
+        end
+    end
+    --Hook the inventories info bar now for the item filtered/shown count
+    hookInventoryInfoBar()
+
+    --PreHook the QuickSlotWindow change filter function
+    local function ChangeFilterQuickSlot(self, filterData)
+        zo_callLater(function()
+            QUICKSLOT_WINDOW:UpdateFreeSlots()
+        end, 50)
+    end
+    ZO_PreHook(QUICKSLOT_WINDOW, "ChangeFilter", ChangeFilterQuickSlot)
+end
+
+local function PresetCraftingStationHookVariables()
+    --Preset the deconstruction/improvement crafting station currentFilter variables with "Weapons"
+    SMITHING.refinementPanel.inventory.currentFilter        = AF.util.MapItemFilterType2CraftingStationFilterType(ITEMFILTERTYPE_AF_REFINE_SMITHING, LF_SMITHING_REFINE, CRAFTING_TYPE_BLACKSMITHING)
+    SMITHING.deconstructionPanel.inventory.currentFilter    = AF.util.MapItemFilterType2CraftingStationFilterType(ITEMFILTERTYPE_AF_WEAPONS_SMITHING, LF_SMITHING_DECONSTRUCT, CRAFTING_TYPE_BLACKSMITHING)
+    SMITHING.improvementPanel.inventory.currentFilter       = AF.util.MapItemFilterType2CraftingStationFilterType(ITEMFILTERTYPE_AF_WEAPONS_SMITHING, LF_SMITHING_IMPROVEMENT, CRAFTING_TYPE_BLACKSMITHING)
+    ENCHANTING.inventory.currentFilter                      = AF.util.MapItemFilterType2CraftingStationFilterType(ITEMFILTERTYPE_AF_GLYPHS_ENCHANTING, LF_ENCHANTING_EXTRACTION, CRAFTING_TYPE_ENCHANTING)
 end
 
 local function CreateSubfilterBars()
     local inventoryNames = {
-        [INVENTORY_BACKPACK] = "PlayerInventory",
-        [INVENTORY_BANK] = "PlayerBank",
-        [INVENTORY_GUILD_BANK] = "GuildBank",
-        [INVENTORY_CRAFT_BAG] = "CraftBag",
-        [6] = "VendorSell",
+        [INVENTORY_BACKPACK]        = "PlayerInventory",
+        [INVENTORY_BANK]            = "PlayerBank",
+        [INVENTORY_GUILD_BANK]      = "GuildBank",
+        [INVENTORY_CRAFT_BAG]       = "CraftBag",
+        [INVENTORY_TYPE_VENDOR_BUY] = "VendorBuy",
+        [LF_SMITHING_REFINE]        = "SmithingRefine",
+        [LF_SMITHING_DECONSTRUCT]   = "SmithingDeconstruction",
+        [LF_SMITHING_IMPROVEMENT]   = "SmithingImprovement",
+        [LF_JEWELRY_REFINE]         = "JewelryCraftingRefine",
+        [LF_JEWELRY_DECONSTRUCT]    = "JewelryCraftingDeconstruction",
+        [LF_JEWELRY_IMPROVEMENT]    = "JewelryCraftingImprovement",
+        [LF_ENCHANTING_CREATION]    = "EnchantingCreation",
+        [LF_ENCHANTING_EXTRACTION]  = "EnchantingExtraction",
+        [INVENTORY_HOUSE_BANK]      = "HouseBankWithdraw",
+    }
+
+    local tradeSkillNames = {
+        [CRAFTING_TYPE_INVALID]         = "_",
+        [CRAFTING_TYPE_ALCHEMY]         = "_ALCHEMY_",
+        [CRAFTING_TYPE_BLACKSMITHING]   = "_BLACKSMITH_",
+        [CRAFTING_TYPE_CLOTHIER]        = "_CLOTHIER_",
+        [CRAFTING_TYPE_ENCHANTING]      = "_ENCHANTING_",
+        [CRAFTING_TYPE_PROVISIONING]    = "_PROVISIONING_",
+        [CRAFTING_TYPE_WOODWORKING]     = "_WOODWORKING_",
+        [CRAFTING_TYPE_JEWELRYCRAFTING] = "_JEWELRY_",
     }
 
     local filterTypeNames = {
-        [ITEMFILTERTYPE_ALL] = "All",
-        [ITEMFILTERTYPE_WEAPONS] = "Weapons",
-        [ITEMFILTERTYPE_ARMOR] = "Armor",
-        [ITEMFILTERTYPE_CONSUMABLE] = "Consumables",
-        [ITEMFILTERTYPE_CRAFTING] = "Crafting",
-        [ITEMFILTERTYPE_FURNISHING] = "Furnishings",
-        [ITEMFILTERTYPE_MISCELLANEOUS] = "Miscellaneous",
-        --[ITEMFILTERTYPE_JUNK] = "Junk",
-        [ITEMFILTERTYPE_BLACKSMITHING] = "Blacksmithing",
-        [ITEMFILTERTYPE_CLOTHING] = "Clothing",
-        [ITEMFILTERTYPE_WOODWORKING] = "Woodworking",
-        [ITEMFILTERTYPE_ALCHEMY] = "Alchemy",
-        [ITEMFILTERTYPE_ENCHANTING] = "Enchanting",
-        [ITEMFILTERTYPE_PROVISIONING] = "Provisioning",
-        [ITEMFILTERTYPE_STYLE_MATERIALS] = "Style",
-        [ITEMFILTERTYPE_TRAIT_ITEMS] = "Traits",
+        [ITEMFILTERTYPE_ALL]                    = AF_CONST_ALL,
+        [ITEMFILTERTYPE_WEAPONS]                = "Weapons",
+        [ITEMFILTERTYPE_AF_WEAPONS_SMITHING]    = "WeaponsSmithing",
+        [ITEMFILTERTYPE_AF_WEAPONS_WOODWORKING] = "WeaponsWoodworking",
+        [ITEMFILTERTYPE_ARMOR]                  = "Armor",
+        [ITEMFILTERTYPE_AF_REFINE_SMITHING]     = "RefineSmithing",
+        [ITEMFILTERTYPE_AF_REFINE_WOODWORKING]  = "RefineWoodworking",
+        [ITEMFILTERTYPE_AF_REFINE_CLOTHIER]     = "RefineClothier",
+        [ITEMFILTERTYPE_AF_ARMOR_SMITHING]      = "ArmorSmithing",
+        [ITEMFILTERTYPE_AF_ARMOR_WOODWORKING]   = "ArmorWoodworking",
+        [ITEMFILTERTYPE_AF_ARMOR_CLOTHIER]      = "ArmorClothier",
+        [ITEMFILTERTYPE_AF_RUNES_ENCHANTING]    = "Runes",
+        [ITEMFILTERTYPE_AF_GLYPHS_ENCHANTING]   = "Glyphs",
+        [ITEMFILTERTYPE_JEWELRY]                = "Jewelry",
+        [ITEMFILTERTYPE_JEWELRYCRAFTING]        = "JewelryCrafting",
+        [ITEMFILTERTYPE_AF_JEWELRY_CRAFTING]    = "JewelryCraftingStation",
+        [ITEMFILTERTYPE_AF_JEWELRY_REFINE]      = "JewelryCraftingStationRefine",
+        [ITEMFILTERTYPE_CONSUMABLE]             = "Consumables",
+        [ITEMFILTERTYPE_CRAFTING]               = "Crafting",
+        [ITEMFILTERTYPE_FURNISHING]             = "Furnishings",
+        [ITEMFILTERTYPE_MISCELLANEOUS]          = "Miscellaneous",
+        --[ITEMFILTERTYPE_JUNK]                   = "Junk",
+        [ITEMFILTERTYPE_BLACKSMITHING]          = "Blacksmithing",
+        [ITEMFILTERTYPE_CLOTHING]               = "Clothing",
+        [ITEMFILTERTYPE_WOODWORKING]            = "Woodworking",
+        [ITEMFILTERTYPE_ALCHEMY]                = "Alchemy",
+        [ITEMFILTERTYPE_ENCHANTING]             = "Enchanting",
+        [ITEMFILTERTYPE_PROVISIONING]           = "Provisioning",
+        [ITEMFILTERTYPE_STYLE_MATERIALS]        = "Style",
+        [ITEMFILTERTYPE_TRAIT_ITEMS]            = "Traits",
     }
+    AF.filterTypes2Names = filterTypeNames
 
     local subfilterButtonNames = {
         [ITEMFILTERTYPE_ALL] = {
-            "All",
+            AF_CONST_ALL,
         },
         [ITEMFILTERTYPE_WEAPONS] = {
-            "HealStaff", "DestructionStaff", "Bow", "TwoHand", "OneHand", "All",
+            "HealStaff", "DestructionStaff", "Bow", "TwoHand", "OneHand", AF_CONST_ALL,
+        },
+        [ITEMFILTERTYPE_AF_REFINE_CLOTHIER] = {
+            "RawMaterial", AF_CONST_ALL,
+        },
+        [ITEMFILTERTYPE_AF_REFINE_SMITHING] = {
+            "RawMaterial", AF_CONST_ALL,
+        },
+        [ITEMFILTERTYPE_AF_REFINE_WOODWORKING] = {
+            "RawMaterial", AF_CONST_ALL,
+        },
+        [ITEMFILTERTYPE_AF_WEAPONS_SMITHING] = {
+            "TwoHand", "OneHand", AF_CONST_ALL,
+        },
+        [ITEMFILTERTYPE_AF_WEAPONS_WOODWORKING] = {
+            "HealStaff", "DestructionStaff", "Bow", AF_CONST_ALL,
         },
         [ITEMFILTERTYPE_ARMOR] = {
-            "Vanity", "Jewelry", "Shield", "Clothing", "LightArmor", "Medium",
-            "Heavy", "All",
+            "Vanity", "Shield", "Clothing", "LightArmor", "Medium",
+            "Heavy", AF_CONST_ALL,
+        },
+        [ITEMFILTERTYPE_JEWELRY] = {
+            "Neck", "Ring", AF_CONST_ALL,
+        },
+        [ITEMFILTERTYPE_AF_ARMOR_SMITHING] = {
+            "Heavy", AF_CONST_ALL,
+        },
+        [ITEMFILTERTYPE_AF_ARMOR_CLOTHIER] = {
+            "LightArmor", "Medium", AF_CONST_ALL,
+        },
+        [ITEMFILTERTYPE_AF_ARMOR_WOODWORKING] = {
+            "Shield", AF_CONST_ALL,
+        },
+        [ITEMFILTERTYPE_AF_RUNES_ENCHANTING] = {
+            AF_CONST_ALL,
+        },
+        [ITEMFILTERTYPE_AF_GLYPHS_ENCHANTING] = {
+            "WeaponGlyph", "ArmorGlyph", "JewelryGlyph", AF_CONST_ALL,
         },
         [ITEMFILTERTYPE_CONSUMABLE] = {
             "Trophy", "Repair", "Container", "Writ", "Motif", "Poison",
-            "Potion", "Recipe", "Drink", "Food", "Crown", "All",
+            "Potion", "Recipe", "Drink", "Food", "Crown", AF_CONST_ALL,
         },
         [ITEMFILTERTYPE_CRAFTING] = {
-            "FurnishingMat", "WeaponTrait", "ArmorTrait", "Style",
-            "Provisioning", "Enchanting", "Alchemy", "Woodworking", "Clothier",
-            "Blacksmithing", "All",
+            "FurnishingMat", "AllTraits", --"JewelryTrait", "WeaponTrait", "ArmorTrait",
+            "Style",
+            "JewelryCrafting", "Provisioning", "Enchanting", "Alchemy", "Woodworking",
+            "Clothier", "Blacksmithing", AF_CONST_ALL,
         },
         [ITEMFILTERTYPE_FURNISHING] = {
             "TargetDummy", "Seating", "Ornamental", "Light", "CraftingStation",
-            "All",
+            AF_CONST_ALL,
         },
         [ITEMFILTERTYPE_MISCELLANEOUS] = {
             "Trash", "Fence", "Trophy", "Tool", "Bait", "Siege", "SoulGem",
-            "Glyphs", "All",
+            "Glyphs", AF_CONST_ALL,
         },
         --[[[ITEMFILTERTYPE_JUNK] = {
             "Miscellaneous", "Materials", "Consumable", "Apparel", "Weapon",
-            "All"
+            AF_CONST_ALL
         },]]
         [ITEMFILTERTYPE_BLACKSMITHING] = {
-            "FurnishingMat", "Temper", "RefinedMaterial", "RawMaterial", "All",
+            "FurnishingMat", "Temper", "RefinedMaterial", "RawMaterial", AF_CONST_ALL,
         },
         [ITEMFILTERTYPE_CLOTHING] = {
-            "FurnishingMat", "Resin", "RefinedMaterial", "RawMaterial", "All",
+            "FurnishingMat", "Resin", "RefinedMaterial", "RawMaterial", AF_CONST_ALL,
         },
         [ITEMFILTERTYPE_WOODWORKING] = {
-            "FurnishingMat", "Tannin", "RefinedMaterial", "RawMaterial", "All",
+            "FurnishingMat", "Tannin", "RefinedMaterial", "RawMaterial", AF_CONST_ALL,
         },
         [ITEMFILTERTYPE_ALCHEMY] = {
-            "FurnishingMat", "Oil", "Water", "Reagent", "All",
+            "FurnishingMat", "Oil", "Water", "Reagent", AF_CONST_ALL,
         },
         [ITEMFILTERTYPE_ENCHANTING] = {
-            "FurnishingMat", "Potency", "Essence", "Aspect", "All",
+            "FurnishingMat", "Potency", "Essence", "Aspect", AF_CONST_ALL,
         },
         [ITEMFILTERTYPE_PROVISIONING] = {
             "FurnishingMat", "Bait", "RareIngredient", "OldIngredient",
-            "DrinkIngredient", "FoodIngredient", "All",
+            "DrinkIngredient", "FoodIngredient", AF_CONST_ALL,
+        },
+        [ITEMFILTERTYPE_JEWELRYCRAFTING] = {
+            "FurnishingMat", "Plating", "RefinedMaterial", "RawPlating", "RawMaterial", AF_CONST_ALL,
+        },
+        [ITEMFILTERTYPE_AF_JEWELRY_CRAFTING] = {
+            "Ring", "Neck", AF_CONST_ALL,
+        },
+        [ITEMFILTERTYPE_AF_JEWELRY_REFINE] = {
+            "RawMaterial", "RawPlating", "RawTrait", AF_CONST_ALL,
         },
         [ITEMFILTERTYPE_STYLE_MATERIALS] = {
             "CrownStyle", "ExoticStyle", "AllianceStyle", "RareStyle",
-            "NormalStyle", "All",
+            "NormalStyle", AF_CONST_ALL,
         },
         [ITEMFILTERTYPE_TRAIT_ITEMS] = {
-            "WeaponTrait", "ArmorTrait", "All",
+           "JewelryTrait", "WeaponTrait", "ArmorTrait", AF_CONST_ALL,
         },
     }
+    --Exclude some of the buttons at an inventory type, craft type, and filter type?
+    --If you add entries be sure to add the other ones, sharing the same AF.subfilterCallbacks[groupName][subfilterName]
+    --as well!
+    --[[
+    local excludeButtonNamesfromSubFilterBar = {
+        --InventoryName
+        [INVENTORY_CRAFT_BAG] = {
+            --TradeSkillNames
+            [CRAFTING_TYPE_INVALID] = {
+                --FilterTypeNames
+                [ITEMFILTERTYPE_CRAFTING] =
+                    --Exclude this single buttons here:
+                    "AllTraits"
+            }
+        },
+        [INVENTORY_BACKPACK] = {
+            [CRAFTING_TYPE_INVALID] = {
+                [ITEMFILTERTYPE_CRAFTING] = {
+                    --Exclude these buttons here:
+                    {"JewelryTrait", "WeaponTrait", "ArmorTrait"}
+                }
+            }
+        },
+        [INVENTORY_BANK] = {
+            [CRAFTING_TYPE_INVALID] = {
+                [ITEMFILTERTYPE_CRAFTING] = {
+                    --Exclude these buttons here:
+                    {"JewelryTrait", "WeaponTrait", "ArmorTrait"}
+                }
+            }
+        },
+        [INVENTORY_GUILD_BANK] = {
+            [CRAFTING_TYPE_INVALID] = {
+                [ITEMFILTERTYPE_CRAFTING] = {
+                    --Exclude these buttons here:
+                    {"JewelryTrait", "WeaponTrait", "ArmorTrait"}
+                }
+            }
+        },
+        [INVENTORY_HOUSE_BANK] = {
+            [CRAFTING_TYPE_INVALID] = {
+                [ITEMFILTERTYPE_CRAFTING] = {
+                    --Exclude these buttons here:
+                    {"JewelryTrait", "WeaponTrait", "ArmorTrait"}
+                }
+            }
+        },
+        [INVENTORY_TYPE_VENDOR_BUY] = {
+            [CRAFTING_TYPE_INVALID] = {
+                [ITEMFILTERTYPE_CRAFTING] = {
+                    --Exclude these buttons here:
+                    {"JewelryTrait", "WeaponTrait", "ArmorTrait"}
+                }
+            }
+        },
+    }
+    ]]
+    local excludeButtonNamesfromSubFilterBar
 
-    for inventoryType, subfilterGroup in pairs(AF.subfilterGroups) do
-        for itemFilterType, _ in pairs(subfilterGroup) do
-            local subfilterBar = AF.AF_FilterBar:New(
-              inventoryNames[inventoryType],
-              filterTypeNames[itemFilterType],
-              subfilterButtonNames[itemFilterType]
-            )
-
-            subfilterBar:SetInventoryType(inventoryType)
-
-            AF.subfilterGroups[inventoryType][itemFilterType] = subfilterBar
+    for inventoryType, tradeSkillTypeSubFilterGroup in pairs(AF.subfilterGroups) do
+        for tradeSkillType, subfilterGroup in pairs(tradeSkillTypeSubFilterGroup) do
+            for itemFilterType, _ in pairs(subfilterGroup) do
+                --Exclusion check
+                local excludeTheseButtons
+                if excludeButtonNamesfromSubFilterBar and excludeButtonNamesfromSubFilterBar[inventoryType] and excludeButtonNamesfromSubFilterBar[inventoryType][tradeSkillType] and excludeButtonNamesfromSubFilterBar[inventoryType][tradeSkillType][itemFilterType] then
+                    excludeTheseButtons = excludeButtonNamesfromSubFilterBar[inventoryType][tradeSkillType][itemFilterType]
+                end
+                --Build the subfilterBar with the buttons now
+                local subfilterBar = AF.AF_FilterBar:New(
+                  inventoryNames[inventoryType],
+                  tradeSkillNames[tradeSkillType],
+                  filterTypeNames[itemFilterType],
+                  subfilterButtonNames[itemFilterType],
+                  excludeTheseButtons
+                )
+                subfilterBar:SetInventoryType(inventoryType)
+                AF.subfilterGroups[inventoryType][tradeSkillType][itemFilterType] = subfilterBar
+            end
         end
     end
+end
+
+local function onEndCraftingStationInteract(eventCode, craftSkill)
+    --Reset the current inventory type to the normal inventory
+    AF.currentInventoryType = INVENTORY_BACKPACK
+end
+local function onCraftingComplete(eventCode)
+    --Update the counter of inventory items currently shown
+    AF.util.updateInventoryInfoBarCountLabel(AF.currentInventoryType, true)
 end
 
 function AdvancedFilters_Loaded(eventCode, addonName)
     if addonName ~= "AdvancedFilters" then return end
     EVENT_MANAGER:UnregisterForEvent("AdvancedFilters_Loaded", EVENT_ADD_ON_LOADED)
 
+    --Register a callback function for crafting stations: If you leave them reseet the current inventory type to INVENTORY_BACKPACK
+    EVENT_MANAGER:RegisterForEvent("AdvancedFilters_CraftingStationLeave", EVENT_END_CRAFTING_STATION_INTERACT, onEndCraftingStationInteract)
+    EVENT_MANAGER:RegisterForEvent("AdvancedFilters_CraftingStationCraftFinished", EVENT_CRAFT_COMPLETED, onCraftingComplete)
+    EVENT_MANAGER:RegisterForEvent("AdvancedFilters_CraftingStationCraftFinished", EVENT_CRAFT_FAILED, onCraftingComplete)
+
     AF.util.LibFilters:InitializeLibFilters()
 
     CreateSubfilterBars()
     InitializeHooks()
+    PresetCraftingStationHookVariables()
 end
 EVENT_MANAGER:RegisterForEvent("AdvancedFilters_Loaded", EVENT_ADD_ON_LOADED, AdvancedFilters_Loaded)


### PR DESCRIPTION
Removed redundant mapping between filterTypes to their name from filename data.lua and added a variable to the global namespace AdvancedFilters.filterTypes2Names.
See file main.lua line 814:
AF.filterTypes2Names = filterTypeNames